### PR TITLE
feat: enhance compareAddress logic and traits handling

### DIFF
--- a/braze/build.gradle
+++ b/braze/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation "org.robolectric:robolectric:4.3"
     testImplementation "androidx.test:core-ktx:1.5.0"
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 
 ext {

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -452,7 +452,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
 
     // compare two address objects and return false if there is a change in address or true otherwise
     private static boolean compareAddress(@Nullable RudderTraits.Address curr, @Nullable RudderTraits.Address prev) {
-        if (prev == null & curr != null) {
+        if (prev == null && curr != null) {
             return false;
         }
         if (prev != null && curr != null) {

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -454,13 +454,15 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
     // compare two address objects and return false if there is a change in address or true otherwise
     @VisibleForTesting
     static boolean compareAddress(@Nullable RudderTraits.Address curr, @Nullable RudderTraits.Address prev) {
-        return
-                (prev != null && curr != null)
-                        && ((curr.getCity() == null || (
-                        prev.getCity() != null && !(prev.getCity().equals(curr.getCity()))
-                )) || (curr.getCountry() == null || (
-                        prev.getCountry() != null && !(prev.getCountry().equals(curr.getCountry()))
-                ))) || (curr == null);
+        return (curr == null) || // if current address is null, we consider address unchanged
+                (prev != null)  // current is non-null, if previous is null will return false
+                        && ((curr.getCity() == null || ( // current city is null, consider city unchanged
+                        prev.getCity() != null && //current city not null previous city if null, address changed
+                                (prev.getCity().equals(curr.getCity())) // match the cities
+                )) && (curr.getCountry() == null || ( // current country is null, consider city unchanged
+                        prev.getCountry() != null && //current country not null previous country if null, address changed
+                                (prev.getCountry().equals(curr.getCountry())) // match the cities
+                )));
 
     }
 

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -55,8 +55,8 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
             "MALE"));
     private static final Set<String> FEMALE_KEYS = new HashSet<>(Arrays.asList("F",
             "FEMALE"));
-    private static final List<String> RESERVED_KEY_SET = Arrays.asList("birthday", "email", "firstName",
-            "lastName", "gender", "phone", "address");
+    private static final List<String> RESERVED_KEY_SET = Arrays.asList("birthday", "email", "firstname",
+            "lastname", "gender", "phone", "address");
 
     // Braze instance
     private Braze braze;
@@ -450,18 +450,32 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
         }
     }
 
-    // compare two address objects and return accordingly
+    // compare two address objects and return false if there is a change in address or true otherwise
     private static boolean compareAddress(@Nullable RudderTraits.Address curr, @Nullable RudderTraits.Address prev) {
-        if (prev == null && curr != null) {
-            return true;
+        if (prev == null & curr != null) {
+            return false;
         }
+        if (prev != null && curr != null) {
+            // if previous identify call doesn't contain city but current one do
+            if (prev.getCity() == null && curr.getCity() != null) {
+                return false;
+            }
+            if (prev.getCity() != null && curr.getCity() != null)
+                if (!(prev.getCity().equals(curr.getCity()))) {
+                    return false;
+                }
 
-        return prev != null && curr != null
-                && prev.getCity().equals(curr.getCity())
-                && prev.getCountry().equals(curr.getCountry())
-                && prev.getPostalCode().equals(curr.getPostalCode())
-                && prev.getState().equals(curr.getState())
-                && prev.getStreet().equals(curr.getStreet());
+            // if previous identify call doesn't contain country but current one do
+            if (prev.getCountry() == null && curr.getCountry() != null) {
+                return false;
+            }
+            if (prev.getCountry() != null && curr.getCountry() != null)
+                if (!(prev.getCountry().equals(curr.getCountry()))) {
+                    return false;
+                }
+        }
+        // all other case, doesn't require any update
+        return true;
     }
 
     private @Nullable

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -8,13 +8,14 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
-import com.braze.Braze;
-import com.braze.configuration.BrazeConfig;
 import com.appboy.enums.Gender;
 import com.appboy.enums.Month;
-import com.braze.models.outgoing.BrazeProperties;
 import com.appboy.models.outgoing.AttributionData;
+import com.braze.Braze;
+import com.braze.configuration.BrazeConfig;
+import com.braze.models.outgoing.BrazeProperties;
 import com.braze.support.BrazeLogger;
 import com.braze.ui.inappmessage.BrazeInAppMessageManager;
 import com.rudderstack.android.sdk.core.MessageType;
@@ -451,31 +452,16 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
     }
 
     // compare two address objects and return false if there is a change in address or true otherwise
-    private static boolean compareAddress(@Nullable RudderTraits.Address curr, @Nullable RudderTraits.Address prev) {
-        if (prev == null && curr != null) {
-            return false;
-        }
-        if (prev != null && curr != null) {
-            // if previous identify call doesn't contain city but current one do
-            if (prev.getCity() == null && curr.getCity() != null) {
-                return false;
-            }
-            if (prev.getCity() != null && curr.getCity() != null)
-                if (!(prev.getCity().equals(curr.getCity()))) {
-                    return false;
-                }
+    @VisibleForTesting
+    static boolean compareAddress(@Nullable RudderTraits.Address curr, @Nullable RudderTraits.Address prev) {
+        return
+                (prev != null && curr != null)
+                        && ((curr.getCity() == null || (
+                        prev.getCity() != null && !(prev.getCity().equals(curr.getCity()))
+                )) || (curr.getCountry() == null || (
+                        prev.getCountry() != null && !(prev.getCountry().equals(curr.getCountry()))
+                ))) || (curr == null);
 
-            // if previous identify call doesn't contain country but current one do
-            if (prev.getCountry() == null && curr.getCountry() != null) {
-                return false;
-            }
-            if (prev.getCountry() != null && curr.getCountry() != null)
-                if (!(prev.getCountry().equals(curr.getCountry()))) {
-                    return false;
-                }
-        }
-        // all other case, doesn't require any update
-        return true;
     }
 
     private @Nullable

--- a/braze/src/test/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactoryTest.java
+++ b/braze/src/test/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactoryTest.java
@@ -1,0 +1,26 @@
+package com.rudderstack.android.integration.braze;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+
+import com.rudderstack.android.sdk.core.RudderTraits;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+
+public class BrazeIntegrationFactoryTest {
+    @Test
+    public void testCompareAddress() {
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(null, null), not(false));
+
+        RudderTraits.Address currAddress = new RudderTraits.Address("city", null, null, null, null);
+        RudderTraits.Address prevAddress = new RudderTraits.Address("city", null, null, null, null);
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(currAddress, null), not(true));
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(null, prevAddress), not(false));
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(currAddress, prevAddress), not(false));
+
+    }
+}

--- a/braze/src/test/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactoryTest.java
+++ b/braze/src/test/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactoryTest.java
@@ -1,9 +1,6 @@
 package com.rudderstack.android.integration.braze;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-
 
 import com.rudderstack.android.sdk.core.RudderTraits;
 
@@ -21,6 +18,47 @@ public class BrazeIntegrationFactoryTest {
         MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(currAddress, null), not(true));
         MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(null, prevAddress), not(false));
         MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(currAddress, prevAddress), not(false));
+
+        RudderTraits.Address address = new RudderTraits.Address();
+        RudderTraits.Address address2 = new RudderTraits.Address()
+                .putCity("City 2");
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address2, address), not(true));
+        // if current city is null, consider unchanged
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address, address2), not(false));
+
+        address = new RudderTraits.Address();
+        address2 = new RudderTraits.Address()
+                .putCountry("Country 2");
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address2, address), not(true));
+        //if current country is null, consider unchanged
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address, address2), not(false));
+
+        //country same, city different
+        address = new RudderTraits.Address()
+                .putCountry("country")
+                .putCity("city1");
+        address2 = new RudderTraits.Address()
+                .putCountry("country")
+                .putCity("city2");
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address2, address), not(true));
+
+        //country different, city same
+        address = new RudderTraits.Address()
+                .putCountry("country1")
+                .putCity("city");
+        address2 = new RudderTraits.Address()
+                .putCountry("country2")
+                .putCity("city");
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address2, address), not(true));
+
+       //same city same country
+        address = new RudderTraits.Address()
+                .putCountry("country")
+                .putCity("city");
+        address2 = new RudderTraits.Address()
+                .putCountry("country")
+                .putCity("city");
+        MatcherAssert.assertThat(BrazeIntegrationFactory.compareAddress(address2, address), not(false));
 
     }
 }

--- a/braze/src/test/java/com/rudderstack/android/sdk/core/positive/SimpleTestCases.java
+++ b/braze/src/test/java/com/rudderstack/android/sdk/core/positive/SimpleTestCases.java
@@ -41,7 +41,7 @@ public class SimpleTestCases extends BaseTestCase {
     public void testSimpleTrackEvent() throws InterruptedException {
         // track event
         try {
-            RudderElement pageViewEvent = new RudderMessageBuilder()
+            RudderMessage pageViewEvent = new RudderMessageBuilder()
                     .setEventName("Test Track")
                     .setProperty(new TrackPropertyBuilder()
                             .setCategory("Test Category")
@@ -51,7 +51,7 @@ public class SimpleTestCases extends BaseTestCase {
             rudderClient.track(pageViewEvent);
             rudderClient.flush();
             Thread.sleep(2000);
-        } catch (RudderException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -60,20 +60,15 @@ public class SimpleTestCases extends BaseTestCase {
     public void testSimplePageViewEvent() throws InterruptedException {
         // page view event
         try {
-            RudderElement pageViewEvent = new RudderMessageBuilder()
-                    .setProperty(new PagePropertyBuilder()
-                            .setUrl("http://jsonviewer.stack.hu")
-                            .setKeywords("Test")
-                            .setPath("http://jsonviewer.stack.hu")
-                            .setReferrer("Test Event")
-                            .setTitle("Test Title")
-                            .setSearch("Test"))
+            RudderMessage pageViewEvent = new RudderMessageBuilder()
+                    .setProperty(new RudderProperty()
+                            .putValue("money", "dollar"))
                     .build();
 
-            rudderClient.page(pageViewEvent);
+            rudderClient.screen(pageViewEvent);
             rudderClient.flush();
             Thread.sleep(2000);
-        } catch (RudderException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -83,14 +78,14 @@ public class SimpleTestCases extends BaseTestCase {
     public void testSimpleScreenViewEvent() throws InterruptedException {
         // screen view event
         try {
-            RudderElement screenViewEvent = new RudderMessageBuilder()
+            RudderMessage screenViewEvent = new RudderMessageBuilder()
                     .setProperty(new ScreenPropertyBuilder()
                             .setScreenName("Test Screen"))
                     .build();
             rudderClient.screen(screenViewEvent);
             rudderClient.flush();
             Thread.sleep(2000);
-        } catch (RudderException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
## Description of the change

Improved the logic to compare two address object, for successive identify call within the same session (i.e., app shouldn't be stopped in between).
Previously, `firstName` and `lastName` traits are being set twice, once as the standard property and next time as the custom property, so I've provided fix for that.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
