### PR TITLE
feat: update braze sdk to latest version 27.0.1

### DIFF
--- a/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
@@ -16,9 +16,8 @@ jobs:
         id: check-outdated-dependencies-and-create-issue
         uses: rudderlabs/github-action-updated-dependencies-notifier@main
         with:
-          outdated-dependency-names: "com.appboy:android-sdk-ui"
+          outdated-dependency-names: "com.braze:android-sdk-ui"
           directory: "braze/build.gradle"
-          repository-urls: "https://appboy.github.io/appboy-android-sdk/sdk"
           title: "fix: update Braze SDK to the latest version"
           assignee: "desusai7"
           labels: "outdatedDependency"

--- a/README.md
+++ b/README.md
@@ -8,23 +8,13 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 
 1. Add [Braze](https://www.braze.com) as a destination in the [Dashboard](https://app.rudderstack.com/) and define ```apiToken```
 
-2. Add these lines to your top-level project ``` build.gradle```
-```
-allprojects {
-  repositories {
-    google()
-    maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
-  }
-}
-```
-
-3. Add the dependency under ```dependencies```
+2. Add the dependency under ```dependencies```
 ```
 implementation 'com.rudderstack.android.sdk:core:[1.0,2.0)'
 implementation 'com.rudderstack.android.integration:braze:1.0.8'
 ```
 
-4. Add required permissions to ```AndroidManifest.xml```
+3. Add required permissions to ```AndroidManifest.xml```
 ```
 <uses-permission android:name="android.permission.INTERNET" />
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/braze/build.gradle
+++ b/braze/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     // RudderStack SDK
     compileOnly 'com.rudderstack.android.sdk:core:[1.12,2.0)'
     // Braze SDK
-    implementation 'com.appboy:android-sdk-ui:[24.3,25.0)'
+    implementation 'com.braze:android-sdk-ui:[27.0,28.0)'
 
     implementation 'com.google.code.gson:gson:2.8.9'
     testImplementation 'com.android.support.test:rules:1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
     }
 }
 


### PR DESCRIPTION
## Description:

- Change the braze dependency from: `com.appboy:android-sdk-ui` to the latest `com.braze:android-sdk-ui`.
- Update the Braze SDK to the latest `v27.0.1`.
- Remove the repository URL for Braze's latest SDK `https://appboy.github.io/appboy-android-sdk/sdk`, as it is no longer required.
- Update the Outdated pod detection CI/CD GitHub action.
- Update readme.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
