### PR TITLE
feat: add missing regions in braze data regions

### DIFF
--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -214,6 +214,9 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
                 case "US-06":
                     customEndPoint = "sdk.iad-06.braze.com";
                     break;
+                case "US-07":
+                    customEndPoint = "sdk.iad-07.braze.com";
+                    break;
                 case "US-08":
                     customEndPoint = "sdk.iad-08.braze.com";
                     break;
@@ -222,6 +225,9 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
                     break;
                 case "EU-02":
                     customEndPoint = "sdk.fra-02.braze.eu";
+                    break;
+                case "AU-01":
+                    customEndPoint = "sdk.au-01.braze.com";
                     break;
             }
             if (customEndPoint == null) {


### PR DESCRIPTION
## Description
This PR adds missing regions - `US-07` and `AU-01` to the braze list of supported regions for data centers.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
