### PR TITLE
feat(ecommerce): map track events to Braze recommended ecommerce events

### DIFF
--- a/braze/build.gradle
+++ b/braze/build.gradle
@@ -20,6 +20,13 @@ android {
     }
 
     namespace 'com.rudderstack.android.integration.braze'
+
+    testOptions {
+        // Let stubbed android.jar calls (e.g. RudderLogger's android.util.Log warnings) no-op instead
+        // of throwing in plain JVM unit tests. The real org.json (test dependency) shadows the stub, so
+        // the JSON-preservation assertions still run against a genuine JSONObject/JSONArray.
+        unitTests.returnDefaultValues = true
+    }
 }
 
 
@@ -38,6 +45,9 @@ dependencies {
     testImplementation "androidx.test:core-ktx:1.5.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation 'com.rudderstack.android.sdk:core:[1.12,2.0)'
+    // Real org.json on the unit-test classpath (the android.jar stub throws "not mocked"); lets the
+    // ecommerce mapping tests assert on the JSONObject/JSONArray produced by Utils.toBrazeJson.
+    testImplementation 'org.json:json:20210307'
 }
 
 

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -124,7 +124,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
 
     // Recommended ecommerce events config flag (default off; on = hard cutover). The mapping logic
     // itself lives in Utils.
-    private static final String USE_RECOMMENDED_ECOMMERCE_EVENTS = "useRecommendedEcommerceEvents";
+    private static final String USE_ECOMMERCE_RECOMMENDED_EVENTS = "useEcommerceRecommendedEvents";
 
     // Array constants
     private static final Set<String> MALE_KEYS = new HashSet<>(Arrays.asList("M",
@@ -150,7 +150,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
     private boolean autoInAppMessageRegEnabled;
     private boolean supportDedup = false; // default it to false
     private ConnectionMode connectionMode;
-    private boolean useRecommendedEcommerceEvents = false;
+    private boolean useEcommerceRecommendedEvents = false;
 
     // Previous identify payload
     private RudderMessage previousIdentifyElement = null;
@@ -267,7 +267,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
             this.connectionMode = getConnectionMode(destinationConfig);
 
             // check for recommended ecommerce events flag. default false
-            this.useRecommendedEcommerceEvents = getBoolean(destinationConfig.get(USE_RECOMMENDED_ECOMMERCE_EVENTS));
+            this.useEcommerceRecommendedEvents = getBoolean(destinationConfig.get(USE_ECOMMERCE_RECOMMENDED_EVENTS));
 
             // all good. initialize braze sdk
             BrazeConfig.Builder builder =
@@ -346,7 +346,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
             // legacy Order Completed / logCustomEvent path. Events with no recommended-event
             // counterpart (Product Clicked, Cart Viewed, Install Attributed, etc.) fall through
             // and keep their existing behaviour.
-            if (useRecommendedEcommerceEvents) {
+            if (useEcommerceRecommendedEvents) {
                 Utils.EcommerceEvent ecommerceEvent = Utils.resolveEcommerceEvent(event);
                 if (ecommerceEvent != null) {
                     Map<String, Object> brazeProperties = Utils.buildEcommerceProperties(ecommerceEvent, eventProperties);

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -120,6 +120,10 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
     private static final String USE_NATIVE_SDK_TO_SEND = "useNativeSDKToSend";
     private static final String CONNECTION_MODE = "connectionMode";
 
+    // Recommended ecommerce events config flag (default off; on = hard cutover). The mapping logic
+    // itself lives in Utils.
+    private static final String USE_RECOMMENDED_ECOMMERCE_EVENTS = "useRecommendedEcommerceEvents";
+
     // Array constants
     private static final Set<String> MALE_KEYS = new HashSet<>(Arrays.asList("M",
             "MALE"));
@@ -144,6 +148,7 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
     private boolean autoInAppMessageRegEnabled;
     private boolean supportDedup = false; // default it to false
     private ConnectionMode connectionMode;
+    private boolean useRecommendedEcommerceEvents = false;
 
     // Previous identify payload
     private RudderMessage previousIdentifyElement = null;
@@ -259,6 +264,9 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
 
             this.connectionMode = getConnectionMode(destinationConfig);
 
+            // check for recommended ecommerce events flag. default false
+            this.useRecommendedEcommerceEvents = getBoolean(destinationConfig.get(USE_RECOMMENDED_ECOMMERCE_EVENTS));
+
             // all good. initialize braze sdk
             BrazeConfig.Builder builder =
                     new BrazeConfig.Builder()
@@ -332,6 +340,21 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
 
         Map<String, Object> eventProperties = element.getProperties();
         try {
+            // When the flag is on, recommended ecommerce events take a hard cutover before the
+            // legacy Order Completed / logCustomEvent path. Events with no recommended-event
+            // counterpart (Product Clicked, Cart Viewed, Install Attributed, etc.) fall through
+            // and keep their existing behaviour.
+            if (useRecommendedEcommerceEvents) {
+                Utils.EcommerceEvent ecommerceEvent = Utils.resolveEcommerceEvent(event);
+                if (ecommerceEvent != null) {
+                    Map<String, Object> brazeProperties = Utils.buildEcommerceProperties(ecommerceEvent, eventProperties);
+                    RudderLogger.logDebug(String.format(
+                            "Braze logCustomEvent for recommended ecommerce event %s with properties %% %s",
+                            ecommerceEvent.getBrazeEvent(), brazeProperties.toString()));
+                    this.braze.logCustomEvent(ecommerceEvent.getBrazeEvent(), new BrazeProperties(brazeProperties));
+                    return;
+                }
+            }
             if (event.equals("Install Attributed")) {
                 if (eventProperties != null && eventProperties.containsKey("campaign") && this.braze.getCurrentUser() != null) {
                     Map<String, Object> campaignProps = (Map<String, Object>) eventProperties.get("campaign");

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/BrazeIntegrationFactory.java
@@ -26,6 +26,8 @@ import com.rudderstack.android.sdk.core.RudderLogger;
 import com.rudderstack.android.sdk.core.RudderMessage;
 import com.rudderstack.android.sdk.core.RudderTraits;
 
+import org.json.JSONObject;
+
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -348,10 +350,13 @@ public class BrazeIntegrationFactory extends RudderIntegration<Braze> {
                 Utils.EcommerceEvent ecommerceEvent = Utils.resolveEcommerceEvent(event);
                 if (ecommerceEvent != null) {
                     Map<String, Object> brazeProperties = Utils.buildEcommerceProperties(ecommerceEvent, eventProperties);
+                    // Convert to JSONObject first: BrazeProperties(Map) drops raw List values in the
+                    // pinned Braze SDK, which would strip products / discounts / type before dispatch.
+                    JSONObject brazeJson = Utils.toBrazeJson(brazeProperties);
                     RudderLogger.logDebug(String.format(
-                            "Braze logCustomEvent for recommended ecommerce event %s with properties %% %s",
-                            ecommerceEvent.getBrazeEvent(), brazeProperties.toString()));
-                    this.braze.logCustomEvent(ecommerceEvent.getBrazeEvent(), new BrazeProperties(brazeProperties));
+                            "Braze logCustomEvent for recommended ecommerce event %s with properties %s",
+                            ecommerceEvent.getBrazeEvent(), brazeJson.toString()));
+                    this.braze.logCustomEvent(ecommerceEvent.getBrazeEvent(), new BrazeProperties(brazeJson));
                     return;
                 }
             }

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
@@ -1,0 +1,451 @@
+package com.rudderstack.android.integration.braze;
+
+import com.rudderstack.android.sdk.core.RudderLogger;
+import com.rudderstack.android.sdk.core.ecomm.ECommerceEvents;
+import com.rudderstack.android.sdk.core.ecomm.ECommerceParamNames;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+// Stateless mapping logic for Braze recommended ecommerce events (gated by
+// useRecommendedEcommerceEvents). Every method here is a pure props -> Map transform; the actual
+// braze.logCustomEvent call stays in BrazeIntegrationFactory.
+class Utils {
+
+    // Braze recommended ecommerce events. action is non-null only for cart_updated
+    // (Product Added -> add, Product Removed -> remove).
+    enum EcommerceEvent {
+        PRODUCT_VIEWED("ecommerce.product_viewed", null),
+        PRODUCT_ADDED("ecommerce.cart_updated", "add"),
+        PRODUCT_REMOVED("ecommerce.cart_updated", "remove"),
+        CHECKOUT_STARTED("ecommerce.checkout_started", null),
+        ORDER_COMPLETED("ecommerce.order_placed", null),
+        ORDER_REFUNDED("ecommerce.order_refunded", null),
+        ORDER_CANCELLED("ecommerce.order_cancelled", null);
+
+        private final String brazeEvent;
+        private final String action;
+
+        EcommerceEvent(String brazeEvent, String action) {
+            this.brazeEvent = brazeEvent;
+            this.action = action;
+        }
+
+        String getBrazeEvent() {
+            return brazeEvent;
+        }
+    }
+
+    // source is hardcoded per platform for mobile device mode (no channel derivation).
+    private static final String SOURCE_KEY = "source";
+    private static final String SOURCE = "android";
+
+    // RudderStack ecommerce source keys. Sourced from the SDK's ECommerceParamNames wherever it
+    // defines a constant; the rest exist only as @SerializedName fields on the ecomm model classes
+    // (ECommerceProduct / ECommerceOrder) and have no referable constant today.
+    private static final String EC_PRODUCT_ID = ECommerceParamNames.PRODUCT_ID;
+    private static final String EC_QUANTITY = ECommerceParamNames.QUANTITY;
+    private static final String EC_PRICE = ECommerceParamNames.PRICE;
+    private static final String EC_CURRENCY = ECommerceParamNames.CURRENCY;
+    private static final String EC_PRODUCTS = ECommerceParamNames.PRODUCTS;
+    private static final String EC_CART_ID = ECommerceParamNames.CART_ID;
+    private static final String EC_CHECKOUT_ID = ECommerceParamNames.CHECKOUT_ID;
+    private static final String EC_ORDER_ID = ECommerceParamNames.ORDER_ID;
+    private static final String EC_TOTAL = ECommerceParamNames.TOTAL;
+    private static final String EC_REVENUE = ECommerceParamNames.REVENUE;
+    private static final String EC_DISCOUNT = ECommerceParamNames.DISCOUNT;
+    // Not exposed as ECommerceParamNames constants (only @SerializedName on the ecomm models):
+    private static final String EC_SKU = "sku";
+    private static final String EC_NAME = "name";
+    private static final String EC_VARIANT = "variant";
+    private static final String EC_IMAGE_URL = "image_url";
+    private static final String EC_URL = "url";
+    private static final String EC_VALUE = "value";
+    private static final String EC_TAX = "tax";
+    private static final String EC_SHIPPING = "shipping";
+    // cancel_reason has no standard RS field at all (Braze-required gap).
+    private static final String EC_CANCEL_REASON = "cancel_reason";
+
+    // Braze recommended-event field names (official Braze schema names — destination side).
+    private static final String BRAZE_PRODUCT_ID = "product_id";
+    private static final String BRAZE_PRODUCT_NAME = "product_name";
+    private static final String BRAZE_VARIANT_ID = "variant_id";
+    private static final String BRAZE_QUANTITY = "quantity";
+    private static final String BRAZE_PRICE = "price";
+    private static final String BRAZE_IMAGE_URL = "image_url";
+    private static final String BRAZE_PRODUCT_URL = "product_url";
+    private static final String BRAZE_CART_ID = "cart_id";
+    private static final String BRAZE_ACTION = "action";
+    private static final String BRAZE_ORDER_ID = "order_id";
+    private static final String BRAZE_CHECKOUT_ID = "checkout_id";
+    private static final String BRAZE_TOTAL_VALUE = "total_value";
+    private static final String BRAZE_CURRENCY = "currency";
+    private static final String BRAZE_PRODUCTS = "products";
+    private static final String BRAZE_TAX = "tax";
+    private static final String BRAZE_SHIPPING = "shipping";
+    private static final String BRAZE_TOTAL_DISCOUNTS = "total_discounts";
+    private static final String BRAZE_CANCEL_REASON = "cancel_reason";
+    private static final String BRAZE_METADATA = "metadata";
+
+    // Consumed-key sets drive metadata pass-through (D6): any RS source key NOT consumed by a
+    // top-level / product mapping flows into metadata / products[].metadata, never left top-level.
+    private static final Set<String> PRODUCT_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL));
+    private static final Set<String> PRODUCT_VIEWED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_PRICE, EC_CURRENCY, EC_IMAGE_URL, EC_URL));
+    private static final Set<String> CART_UPDATED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_CART_ID, EC_CURRENCY, EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE,
+            EC_IMAGE_URL, EC_URL));
+    private static final Set<String> CHECKOUT_STARTED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_CHECKOUT_ID, EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX,
+            EC_SHIPPING));
+    private static final Set<String> ORDER_PLACED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING,
+            EC_DISCOUNT));
+    private static final Set<String> ORDER_REFUNDED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS));
+    private static final Set<String> ORDER_CANCELLED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_ORDER_ID, EC_TOTAL, EC_CURRENCY, EC_CANCEL_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING,
+            EC_DISCOUNT));
+
+    // Case-insensitive RudderStack event name -> Braze recommended event.
+    private static final Map<String, EcommerceEvent> ECOMMERCE_EVENT_MAPPING = buildEcommerceEventMapping();
+
+    private static Map<String, EcommerceEvent> buildEcommerceEventMapping() {
+        // Keys are the RudderStack ecommerce event names (from the SDK's ECommerceEvents),
+        // lowercased for case-insensitive lookup.
+        Map<String, EcommerceEvent> mapping = new HashMap<>();
+        mapping.put(lowerCase(ECommerceEvents.PRODUCT_VIEWED), EcommerceEvent.PRODUCT_VIEWED);
+        mapping.put(lowerCase(ECommerceEvents.PRODUCT_ADDED), EcommerceEvent.PRODUCT_ADDED);
+        mapping.put(lowerCase(ECommerceEvents.PRODUCT_REMOVED), EcommerceEvent.PRODUCT_REMOVED);
+        mapping.put(lowerCase(ECommerceEvents.CHECKOUT_STARTED), EcommerceEvent.CHECKOUT_STARTED);
+        mapping.put(lowerCase(ECommerceEvents.ORDER_COMPLETED), EcommerceEvent.ORDER_COMPLETED);
+        mapping.put(lowerCase(ECommerceEvents.ORDER_REFUNDED), EcommerceEvent.ORDER_REFUNDED);
+        mapping.put(lowerCase(ECommerceEvents.ORDER_CANCELLED), EcommerceEvent.ORDER_CANCELLED);
+        return mapping;
+    }
+
+    private static String lowerCase(String value) {
+        return value.toLowerCase(Locale.US);
+    }
+
+    // Resolves a RudderStack event name to its Braze recommended event (case-insensitive).
+    // Returns null for events without a recommended-event counterpart.
+    static EcommerceEvent resolveEcommerceEvent(String eventName) {
+        if (eventName == null) {
+            return null;
+        }
+        return ECOMMERCE_EVENT_MAPPING.get(eventName.trim().toLowerCase(Locale.US));
+    }
+
+    // Builds the Braze custom-event property map for a recommended ecommerce event.
+    // Send-anyway posture (D5): build from an empty map when properties are absent so the event is
+    // still logged (with required-field warnings) rather than dropped.
+    static Map<String, Object> buildEcommerceProperties(EcommerceEvent ecommerceEvent, Map<String, Object> properties) {
+        Map<String, Object> props = (properties != null) ? properties : new HashMap<>();
+        switch (ecommerceEvent) {
+            case PRODUCT_VIEWED:
+                return buildProductViewed(props);
+            case PRODUCT_ADDED:
+            case PRODUCT_REMOVED:
+                return buildCartUpdated(props, ecommerceEvent.action);
+            case CHECKOUT_STARTED:
+                return buildCheckoutStarted(props);
+            case ORDER_COMPLETED:
+                return buildOrderPlaced(props);
+            case ORDER_REFUNDED:
+                return buildOrderRefunded(props);
+            case ORDER_CANCELLED:
+                return buildOrderCancelled(props);
+            default:
+                return new HashMap<>();
+        }
+    }
+
+    // ecommerce.product_viewed — flat, single-product event (no products array, no quantity).
+    private static Map<String, Object> buildProductViewed(Map<String, Object> props) {
+        String brazeEvent = EcommerceEvent.PRODUCT_VIEWED.brazeEvent;
+        Map<String, Object> out = new HashMap<>();
+
+        Object productId = firstNonNull(props, EC_PRODUCT_ID, EC_SKU);
+        Object productName = firstNonNull(props, EC_NAME);
+        Object variantId = firstNonNull(props, EC_VARIANT, EC_SKU, EC_PRODUCT_ID);
+        Object price = firstNonNull(props, EC_PRICE);
+        Object currency = firstNonNull(props, EC_CURRENCY);
+
+        warnIfMissing(brazeEvent, BRAZE_PRODUCT_ID, productId);
+        warnIfMissing(brazeEvent, BRAZE_PRODUCT_NAME, productName);
+        warnIfMissing(brazeEvent, BRAZE_VARIANT_ID, variantId);
+        warnIfMissing(brazeEvent, BRAZE_PRICE, price);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+
+        putIfPresent(out, BRAZE_PRODUCT_ID, productId);
+        putIfPresent(out, BRAZE_PRODUCT_NAME, productName);
+        putIfPresent(out, BRAZE_VARIANT_ID, variantId);
+        putIfPresent(out, BRAZE_PRICE, price);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        putIfPresent(out, BRAZE_IMAGE_URL, firstNonNull(props, EC_IMAGE_URL));
+        putIfPresent(out, BRAZE_PRODUCT_URL, firstNonNull(props, EC_URL));
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, PRODUCT_VIEWED_CONSUMED_KEYS);
+        return out;
+    }
+
+    // ecommerce.cart_updated — Product Added/Removed; single top-level product wrapped into a
+    // 1-element products array. action is the only difference between add and remove.
+    private static Map<String, Object> buildCartUpdated(Map<String, Object> props, String action) {
+        String brazeEvent = EcommerceEvent.PRODUCT_ADDED.brazeEvent; // ecommerce.cart_updated
+        Map<String, Object> out = new HashMap<>();
+
+        Object cartId = firstNonNull(props, EC_CART_ID);
+        Object currency = firstNonNull(props, EC_CURRENCY);
+        Map<String, Object> product = buildProductFields(props);
+
+        warnIfMissing(brazeEvent, BRAZE_CART_ID, cartId);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+        if (product.isEmpty()) {
+            warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
+        }
+
+        putIfPresent(out, BRAZE_CART_ID, cartId);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        out.put(BRAZE_ACTION, action);
+        if (!product.isEmpty()) {
+            List<Map<String, Object>> products = new ArrayList<>();
+            products.add(product);
+            out.put(BRAZE_PRODUCTS, products);
+        }
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, CART_UPDATED_CONSUMED_KEYS);
+        return out;
+    }
+
+    // ecommerce.checkout_started — checkout_id falls back to order_id.
+    private static Map<String, Object> buildCheckoutStarted(Map<String, Object> props) {
+        String brazeEvent = EcommerceEvent.CHECKOUT_STARTED.brazeEvent;
+        Map<String, Object> out = new HashMap<>();
+
+        Object checkoutId = firstNonNull(props, EC_CHECKOUT_ID, EC_ORDER_ID);
+        Object totalValue = firstNonNull(props, EC_TOTAL, EC_REVENUE, EC_VALUE);
+        Object currency = firstNonNull(props, EC_CURRENCY);
+        List<Map<String, Object>> products = buildProducts(props);
+
+        warnIfMissing(brazeEvent, BRAZE_CHECKOUT_ID, checkoutId);
+        warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+        if (products == null) {
+            warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
+        }
+
+        putIfPresent(out, BRAZE_CHECKOUT_ID, checkoutId);
+        putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        if (products != null) {
+            out.put(BRAZE_PRODUCTS, products);
+        }
+        putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
+        putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, CHECKOUT_STARTED_CONSUMED_KEYS);
+        return out;
+    }
+
+    // ecommerce.order_placed — Order Completed. One event per order with all products inside
+    // products[] (vs. the legacy one-purchase-per-product model).
+    private static Map<String, Object> buildOrderPlaced(Map<String, Object> props) {
+        String brazeEvent = EcommerceEvent.ORDER_COMPLETED.brazeEvent; // ecommerce.order_placed
+        Map<String, Object> out = new HashMap<>();
+
+        Object orderId = firstNonNull(props, EC_ORDER_ID);
+        Object totalValue = firstNonNull(props, EC_TOTAL, EC_REVENUE, EC_VALUE);
+        Object currency = firstNonNull(props, EC_CURRENCY);
+        List<Map<String, Object>> products = buildProducts(props);
+
+        warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+        warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+        if (products == null) {
+            warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
+        }
+
+        putIfPresent(out, BRAZE_ORDER_ID, orderId);
+        putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        if (products != null) {
+            out.put(BRAZE_PRODUCTS, products);
+        }
+        putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
+        putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
+        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT));
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, ORDER_PLACED_CONSUMED_KEYS);
+        return out;
+    }
+
+    // ecommerce.order_refunded — RS Order Refunded carries only order_id today; total_value,
+    // currency and products are RS-spec gaps (mapped if present, warned if absent).
+    private static Map<String, Object> buildOrderRefunded(Map<String, Object> props) {
+        String brazeEvent = EcommerceEvent.ORDER_REFUNDED.brazeEvent;
+        Map<String, Object> out = new HashMap<>();
+
+        Object orderId = firstNonNull(props, EC_ORDER_ID);
+        Object totalValue = firstNonNull(props, EC_TOTAL, EC_REVENUE, EC_VALUE);
+        Object currency = firstNonNull(props, EC_CURRENCY);
+        List<Map<String, Object>> products = buildProducts(props);
+
+        warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+        warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+        if (products == null) {
+            warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
+        }
+
+        putIfPresent(out, BRAZE_ORDER_ID, orderId);
+        putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        if (products != null) {
+            out.put(BRAZE_PRODUCTS, products);
+        }
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, ORDER_REFUNDED_CONSUMED_KEYS);
+        return out;
+    }
+
+    // ecommerce.order_cancelled — total_value is the absolute value of total; cancel_reason has
+    // no standard RS source (mapped if present, warned if absent).
+    private static Map<String, Object> buildOrderCancelled(Map<String, Object> props) {
+        String brazeEvent = EcommerceEvent.ORDER_CANCELLED.brazeEvent;
+        Map<String, Object> out = new HashMap<>();
+
+        Object orderId = firstNonNull(props, EC_ORDER_ID);
+        Object totalValue = toAbsoluteValue(firstNonNull(props, EC_TOTAL));
+        Object currency = firstNonNull(props, EC_CURRENCY);
+        Object cancelReason = firstNonNull(props, EC_CANCEL_REASON);
+        List<Map<String, Object>> products = buildProducts(props);
+
+        warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+        warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+        warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+        warnIfMissing(brazeEvent, BRAZE_CANCEL_REASON, cancelReason);
+        if (products == null) {
+            warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
+        }
+
+        putIfPresent(out, BRAZE_ORDER_ID, orderId);
+        putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+        putIfPresent(out, BRAZE_CURRENCY, currency);
+        putIfPresent(out, BRAZE_CANCEL_REASON, cancelReason);
+        if (products != null) {
+            out.put(BRAZE_PRODUCTS, products);
+        }
+        putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
+        putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
+        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT));
+        out.put(SOURCE_KEY, SOURCE);
+
+        putMetadata(out, props, ORDER_CANCELLED_CONSUMED_KEYS);
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> buildProducts(Map<String, Object> props) {
+        Object raw = props.get(EC_PRODUCTS);
+        if (!(raw instanceof List)) {
+            return null;
+        }
+        List<?> rsProducts = (List<?>) raw;
+        List<Map<String, Object>> products = new ArrayList<>();
+        for (Object item : rsProducts) {
+            if (item instanceof Map) {
+                products.add(buildProduct((Map<String, Object>) item));
+            }
+        }
+        return products.isEmpty() ? null : products;
+    }
+
+    private static Map<String, Object> buildProduct(Map<String, Object> rsProduct) {
+        Map<String, Object> product = buildProductFields(rsProduct);
+        putMetadata(product, rsProduct, PRODUCT_CONSUMED_KEYS);
+        return product;
+    }
+
+    // Maps the shared Braze product object (no metadata). cart_updated routes leftover product
+    // keys into event-level metadata, so it uses this directly; array products add per-product
+    // metadata via buildProduct.
+    private static Map<String, Object> buildProductFields(Map<String, Object> rsProduct) {
+        Map<String, Object> product = new HashMap<>();
+        putIfPresent(product, BRAZE_PRODUCT_ID, firstNonNull(rsProduct, EC_PRODUCT_ID, EC_SKU));
+        putIfPresent(product, BRAZE_PRODUCT_NAME, firstNonNull(rsProduct, EC_NAME));
+        putIfPresent(product, BRAZE_VARIANT_ID, firstNonNull(rsProduct, EC_VARIANT, EC_SKU, EC_PRODUCT_ID));
+        putIfPresent(product, BRAZE_QUANTITY, firstNonNull(rsProduct, EC_QUANTITY));
+        putIfPresent(product, BRAZE_PRICE, firstNonNull(rsProduct, EC_PRICE));
+        putIfPresent(product, BRAZE_IMAGE_URL, firstNonNull(rsProduct, EC_IMAGE_URL));
+        putIfPresent(product, BRAZE_PRODUCT_URL, firstNonNull(rsProduct, EC_URL));
+        return product;
+    }
+
+    // D6: any source key not consumed by a mapping flows into metadata (never left top-level).
+    private static void putMetadata(Map<String, Object> target, Map<String, Object> props, Set<String> consumedKeys) {
+        Map<String, Object> metadata = new HashMap<>();
+        for (Map.Entry<String, Object> entry : props.entrySet()) {
+            if (!consumedKeys.contains(entry.getKey())) {
+                metadata.put(entry.getKey(), entry.getValue());
+            }
+        }
+        if (!metadata.isEmpty()) {
+            target.put(BRAZE_METADATA, metadata);
+        }
+    }
+
+    // Returns the first non-null, non-empty value among the given keys (fallback chain).
+    private static Object firstNonNull(Map<String, Object> props, String... keys) {
+        if (props == null) {
+            return null;
+        }
+        for (String key : keys) {
+            Object value = props.get(key);
+            if (value != null && !(value instanceof String && ((String) value).isEmpty())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static void putIfPresent(Map<String, Object> target, String key, Object value) {
+        if (value != null) {
+            target.put(key, value);
+        }
+    }
+
+    // Send-anyway validation (D5): a missing Braze-required field is logged but never drops the
+    // event. source is intentionally never checked here — it always resolves to the platform.
+    private static void warnIfMissing(String brazeEvent, String field, Object value) {
+        if (value == null) {
+            RudderLogger.logWarn(String.format(
+                    "BrazeIntegrationFactory: recommended event %s is missing required field '%s'; sending event anyway.",
+                    brazeEvent, field));
+        }
+    }
+
+    private static Object toAbsoluteValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Math.abs(Double.parseDouble(String.valueOf(value)));
+        } catch (NumberFormatException exception) {
+            return value;
+        }
+    }
+}

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
@@ -4,6 +4,10 @@ import com.rudderstack.android.sdk.core.RudderLogger;
 import com.rudderstack.android.sdk.core.ecomm.ECommerceEvents;
 import com.rudderstack.android.sdk.core.ecomm.ECommerceParamNames;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -233,6 +237,40 @@ class Utils {
         return out;
     }
 
+    // Converts the built property Map into a JSONObject (recursively wrapping nested List -> JSONArray
+    // and Map -> JSONObject) so it can be handed to BrazeProperties(JSONObject). This mirrors the
+    // Kotlin integration (BrazeProperties(properties.toJSONObject())): the pinned Braze SDK's
+    // BrazeProperties(Map) constructor silently drops raw java.util.List values, which would strip
+    // products / discounts / type before dispatch. Building a JSONObject first preserves them.
+    static JSONObject toBrazeJson(Map<String, Object> map) {
+        JSONObject json = new JSONObject();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            try {
+                json.put(entry.getKey(), toBrazeJsonValue(entry.getValue()));
+            } catch (JSONException e) {
+                RudderLogger.logWarn(String.format(
+                        "BrazeIntegrationFactory: failed to add field '%s' to recommended ecommerce event payload: %s",
+                        entry.getKey(), e.getMessage()));
+            }
+        }
+        return json;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object toBrazeJsonValue(Object value) {
+        if (value instanceof Map) {
+            return toBrazeJson((Map<String, Object>) value);
+        }
+        if (value instanceof List) {
+            JSONArray array = new JSONArray();
+            for (Object item : (List<Object>) value) {
+                array.put(toBrazeJsonValue(item));
+            }
+            return array;
+        }
+        return value;
+    }
+
     // ecommerce.product_viewed — flat, single-product event (no products array, no quantity).
     private static Map<String, Object> buildProductViewed(Map<String, Object> props) {
         String brazeEvent = EcommerceEvent.PRODUCT_VIEWED.brazeEvent;
@@ -447,7 +485,13 @@ class Utils {
         List<Map<String, Object>> products = new ArrayList<>();
         for (Object item : rsProducts) {
             if (item instanceof Map) {
-                products.add(buildProduct((Map<String, Object>) item));
+                Map<String, Object> product = buildProduct((Map<String, Object>) item);
+                // Skip empty product maps so an all-empty products array is treated as "no products"
+                // (omitted + missing-field warning) rather than sending products: [ {} ]. Mirrors the
+                // Kotlin integration's trailing filter { it.isNotEmpty() }.
+                if (!product.isEmpty()) {
+                    products.add(product);
+                }
             }
         }
         return products.isEmpty() ? null : products;

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
@@ -69,8 +69,13 @@ class Utils {
     private static final String EC_VALUE = "value";
     private static final String EC_TAX = "tax";
     private static final String EC_SHIPPING = "shipping";
-    // cancel_reason has no standard RS field at all (Braze-required gap).
+    private static final String EC_TYPE = "type";
+    private static final String EC_SUBTOTAL_VALUE = "subtotal_value";
+    private static final String EC_DISCOUNTS = "discounts";
+    private static final String EC_TOTAL_DISCOUNTS = "total_discounts";
+    // cancel_reason / reason are both valid RS sources for Braze's required cancel_reason.
     private static final String EC_CANCEL_REASON = "cancel_reason";
+    private static final String EC_REASON = ECommerceParamNames.REASON;
 
     // Braze recommended-event field names (official Braze schema names — destination side).
     private static final String BRAZE_PRODUCT_ID = "product_id";
@@ -91,6 +96,9 @@ class Utils {
     private static final String BRAZE_SHIPPING = "shipping";
     private static final String BRAZE_TOTAL_DISCOUNTS = "total_discounts";
     private static final String BRAZE_CANCEL_REASON = "cancel_reason";
+    private static final String BRAZE_TYPE = "type";
+    private static final String BRAZE_SUBTOTAL_VALUE = "subtotal_value";
+    private static final String BRAZE_DISCOUNTS = "discounts";
     private static final String BRAZE_METADATA = "metadata";
 
     // Consumed-key sets drive metadata pass-through (D6): any RS source key NOT consumed by a
@@ -98,21 +106,23 @@ class Utils {
     private static final Set<String> PRODUCT_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
             EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL));
     private static final Set<String> PRODUCT_VIEWED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_PRICE, EC_CURRENCY, EC_IMAGE_URL, EC_URL));
+            EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_PRICE, EC_CURRENCY, EC_IMAGE_URL, EC_URL,
+            EC_TYPE));
     private static final Set<String> CART_UPDATED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
             EC_CART_ID, EC_CURRENCY, EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE,
-            EC_IMAGE_URL, EC_URL));
+            EC_IMAGE_URL, EC_URL, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING));
     private static final Set<String> CHECKOUT_STARTED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_CHECKOUT_ID, EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX,
-            EC_SHIPPING));
+            EC_CHECKOUT_ID, EC_ORDER_ID, EC_CART_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE,
+            EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING));
     private static final Set<String> ORDER_PLACED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING,
-            EC_DISCOUNT));
+            EC_ORDER_ID, EC_CART_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY,
+            EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS));
     private static final Set<String> ORDER_REFUNDED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS));
+            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_DISCOUNT,
+            EC_TOTAL_DISCOUNTS, EC_DISCOUNTS));
     private static final Set<String> ORDER_CANCELLED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_ORDER_ID, EC_TOTAL, EC_CURRENCY, EC_CANCEL_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING,
-            EC_DISCOUNT));
+            EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_CANCEL_REASON,
+            EC_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS));
 
     // Case-insensitive RudderStack event name -> Braze recommended event.
     private static final Map<String, EcommerceEvent> ECOMMERCE_EVENT_MAPPING = buildEcommerceEventMapping();
@@ -192,6 +202,7 @@ class Utils {
         putIfPresent(out, BRAZE_CURRENCY, currency);
         putIfPresent(out, BRAZE_IMAGE_URL, firstNonNull(props, EC_IMAGE_URL));
         putIfPresent(out, BRAZE_PRODUCT_URL, firstNonNull(props, EC_URL));
+        putIfPresent(out, BRAZE_TYPE, firstNonNull(props, EC_TYPE));
         out.put(SOURCE_KEY, SOURCE);
 
         putMetadata(out, props, PRODUCT_VIEWED_CONSUMED_KEYS);
@@ -216,6 +227,10 @@ class Utils {
 
         putIfPresent(out, BRAZE_CART_ID, cartId);
         putIfPresent(out, BRAZE_CURRENCY, currency);
+        putIfPresent(out, BRAZE_TOTAL_VALUE, firstNonNull(props, EC_TOTAL, EC_VALUE));
+        putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, EC_SUBTOTAL_VALUE));
+        putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
+        putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
         out.put(BRAZE_ACTION, action);
         if (!product.isEmpty()) {
             List<Map<String, Object>> products = new ArrayList<>();
@@ -251,6 +266,8 @@ class Utils {
         if (products != null) {
             out.put(BRAZE_PRODUCTS, products);
         }
+        putIfPresent(out, BRAZE_CART_ID, firstNonNull(props, EC_CART_ID));
+        putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, EC_SUBTOTAL_VALUE));
         putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
         putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
         out.put(SOURCE_KEY, SOURCE);
@@ -283,9 +300,12 @@ class Utils {
         if (products != null) {
             out.put(BRAZE_PRODUCTS, products);
         }
+        putIfPresent(out, BRAZE_CART_ID, firstNonNull(props, EC_CART_ID));
         putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
         putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
-        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT));
+        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT, EC_TOTAL_DISCOUNTS));
+        putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, EC_SUBTOTAL_VALUE));
+        putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
         putMetadata(out, props, ORDER_PLACED_CONSUMED_KEYS);
@@ -316,22 +336,24 @@ class Utils {
         if (products != null) {
             out.put(BRAZE_PRODUCTS, products);
         }
+        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT, EC_TOTAL_DISCOUNTS));
+        putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
         putMetadata(out, props, ORDER_REFUNDED_CONSUMED_KEYS);
         return out;
     }
 
-    // ecommerce.order_cancelled — total_value is the absolute value of total; cancel_reason has
-    // no standard RS source (mapped if present, warned if absent).
+    // ecommerce.order_cancelled — cancel_reason falls back to the standard RS reason field
+    // (mapped if present, warned if absent).
     private static Map<String, Object> buildOrderCancelled(Map<String, Object> props) {
         String brazeEvent = EcommerceEvent.ORDER_CANCELLED.brazeEvent;
         Map<String, Object> out = new HashMap<>();
 
         Object orderId = firstNonNull(props, EC_ORDER_ID);
-        Object totalValue = toAbsoluteValue(firstNonNull(props, EC_TOTAL));
+        Object totalValue = firstNonNull(props, EC_TOTAL, EC_REVENUE, EC_VALUE);
         Object currency = firstNonNull(props, EC_CURRENCY);
-        Object cancelReason = firstNonNull(props, EC_CANCEL_REASON);
+        Object cancelReason = firstNonNull(props, EC_CANCEL_REASON, EC_REASON);
         List<Map<String, Object>> products = buildProducts(props);
 
         warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
@@ -351,7 +373,9 @@ class Utils {
         }
         putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
         putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
-        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT));
+        putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, EC_DISCOUNT, EC_TOTAL_DISCOUNTS));
+        putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, EC_SUBTOTAL_VALUE));
+        putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
         putMetadata(out, props, ORDER_CANCELLED_CONSUMED_KEYS);
@@ -435,17 +459,6 @@ class Utils {
             RudderLogger.logWarn(String.format(
                     "BrazeIntegrationFactory: recommended event %s is missing required field '%s'; sending event anyway.",
                     brazeEvent, field));
-        }
-    }
-
-    private static Object toAbsoluteValue(Object value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return Math.abs(Double.parseDouble(String.valueOf(value)));
-        } catch (NumberFormatException exception) {
-            return value;
         }
     }
 }

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
@@ -4,10 +4,12 @@ import com.rudderstack.android.sdk.core.RudderLogger;
 import com.rudderstack.android.sdk.core.ecomm.ECommerceEvents;
 import com.rudderstack.android.sdk.core.ecomm.ECommerceParamNames;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -124,6 +126,50 @@ class Utils {
             EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_CANCEL_REASON,
             EC_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS));
 
+    // The data type Braze expects for a recommended-event field. Resolved values are coerced to this
+    // type where possible; a value that cannot be coerced is sent as-is and surfaced via a warning.
+    enum BrazeFieldType {
+        STRING,
+        INTEGER,
+        FLOAT,
+        STRING_ARRAY,
+        ARRAY
+    }
+
+    // Expected Braze type per recommended-event field (Braze dest key -> type). Each field has a
+    // single type across every event, so one table drives coercion and the type-mismatch warning for
+    // both top-level and products[] fields; keys absent from a given event are simply skipped. Control
+    // fields (source, action, products, metadata) are intentionally omitted. Order here is the order
+    // fields appear in the warning.
+    private static final Map<String, BrazeFieldType> FIELD_TYPES = orderedTypes(
+            BRAZE_PRODUCT_ID, BrazeFieldType.STRING,
+            BRAZE_PRODUCT_NAME, BrazeFieldType.STRING,
+            BRAZE_VARIANT_ID, BrazeFieldType.STRING,
+            BRAZE_QUANTITY, BrazeFieldType.INTEGER,
+            BRAZE_PRICE, BrazeFieldType.FLOAT,
+            BRAZE_IMAGE_URL, BrazeFieldType.STRING,
+            BRAZE_PRODUCT_URL, BrazeFieldType.STRING,
+            BRAZE_CART_ID, BrazeFieldType.STRING,
+            BRAZE_CHECKOUT_ID, BrazeFieldType.STRING,
+            BRAZE_ORDER_ID, BrazeFieldType.STRING,
+            BRAZE_CURRENCY, BrazeFieldType.STRING,
+            BRAZE_TOTAL_VALUE, BrazeFieldType.FLOAT,
+            BRAZE_SUBTOTAL_VALUE, BrazeFieldType.FLOAT,
+            BRAZE_TAX, BrazeFieldType.FLOAT,
+            BRAZE_SHIPPING, BrazeFieldType.FLOAT,
+            BRAZE_TOTAL_DISCOUNTS, BrazeFieldType.FLOAT,
+            BRAZE_CANCEL_REASON, BrazeFieldType.STRING,
+            BRAZE_TYPE, BrazeFieldType.STRING_ARRAY,
+            BRAZE_DISCOUNTS, BrazeFieldType.ARRAY);
+
+    private static Map<String, BrazeFieldType> orderedTypes(Object... pairs) {
+        Map<String, BrazeFieldType> map = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            map.put((String) pairs[i], (BrazeFieldType) pairs[i + 1]);
+        }
+        return map;
+    }
+
     // Case-insensitive RudderStack event name -> Braze recommended event.
     private static final Map<String, EcommerceEvent> ECOMMERCE_EVENT_MAPPING = buildEcommerceEventMapping();
 
@@ -159,23 +205,32 @@ class Utils {
     // still logged (with required-field warnings) rather than dropped.
     static Map<String, Object> buildEcommerceProperties(EcommerceEvent ecommerceEvent, Map<String, Object> properties) {
         Map<String, Object> props = (properties != null) ? properties : new HashMap<>();
+        Map<String, Object> out;
         switch (ecommerceEvent) {
             case PRODUCT_VIEWED:
-                return buildProductViewed(props);
+                out = buildProductViewed(props);
+                break;
             case PRODUCT_ADDED:
             case PRODUCT_REMOVED:
-                return buildCartUpdated(props, ecommerceEvent.action);
+                out = buildCartUpdated(props, ecommerceEvent.action);
+                break;
             case CHECKOUT_STARTED:
-                return buildCheckoutStarted(props);
+                out = buildCheckoutStarted(props);
+                break;
             case ORDER_COMPLETED:
-                return buildOrderPlaced(props);
+                out = buildOrderPlaced(props);
+                break;
             case ORDER_REFUNDED:
-                return buildOrderRefunded(props);
+                out = buildOrderRefunded(props);
+                break;
             case ORDER_CANCELLED:
-                return buildOrderCancelled(props);
+                out = buildOrderCancelled(props);
+                break;
             default:
                 return new HashMap<>();
         }
+        coerceAndWarnTypes(ecommerceEvent.getBrazeEvent(), out);
+        return out;
     }
 
     // ecommerce.product_viewed — flat, single-product event (no products array, no quantity).
@@ -459,6 +514,133 @@ class Utils {
             RudderLogger.logWarn(String.format(
                     "BrazeIntegrationFactory: recommended event %s is missing required field '%s'; sending event anyway.",
                     brazeEvent, field));
+        }
+    }
+
+    // Coerces each resolved field toward the type Braze expects (in place) and logs a single warning
+    // listing any field whose value still does not match after coercion. The same FIELD_TYPES table
+    // covers both top-level and products[] fields. Values are never dropped: an un-coercible value is
+    // sent as-is and only surfaced in the warning.
+    @SuppressWarnings("unchecked")
+    private static void coerceAndWarnTypes(String brazeEvent, Map<String, Object> out) {
+        List<String> mismatched = new ArrayList<>();
+
+        for (Map.Entry<String, BrazeFieldType> entry : FIELD_TYPES.entrySet()) {
+            if (out.containsKey(entry.getKey())) {
+                Object coerced = coerceToType(out.get(entry.getKey()), entry.getValue());
+                out.put(entry.getKey(), coerced);
+                if (!matchesType(coerced, entry.getValue())) {
+                    mismatched.add(entry.getKey() + " (expected " + entry.getValue() + ")");
+                }
+            }
+        }
+
+        if (out.get(BRAZE_PRODUCTS) instanceof List) {
+            List<Map<String, Object>> products = (List<Map<String, Object>>) out.get(BRAZE_PRODUCTS);
+            for (Map.Entry<String, BrazeFieldType> entry : FIELD_TYPES.entrySet()) {
+                boolean anyMismatch = false;
+                for (Map<String, Object> product : products) {
+                    if (product.containsKey(entry.getKey())) {
+                        Object coerced = coerceToType(product.get(entry.getKey()), entry.getValue());
+                        product.put(entry.getKey(), coerced);
+                        anyMismatch |= !matchesType(coerced, entry.getValue());
+                    }
+                }
+                if (anyMismatch) {
+                    mismatched.add("products[]." + entry.getKey() + " (expected " + entry.getValue() + ")");
+                }
+            }
+        }
+
+        if (!mismatched.isEmpty()) {
+            RudderLogger.logWarn(String.format(
+                    "BrazeIntegrationFactory: recommended event %s has type-mismatched field(s) (sent as-is): %s",
+                    brazeEvent, mismatched));
+        }
+    }
+
+    // Coerces a primitive value toward the expected type where possible: numeric string -> number,
+    // number/boolean -> string. Numbers are left as-is for numeric fields (Braze accepts an integer
+    // where a float is expected). Anything that cannot be coerced is returned unchanged.
+    private static Object coerceToType(Object value, BrazeFieldType type) {
+        switch (type) {
+            case STRING:
+                if (value instanceof Number || value instanceof Boolean) {
+                    return String.valueOf(value);
+                }
+                return value;
+            case FLOAT:
+                if (value instanceof String) {
+                    Double parsed = parseDoubleOrNull((String) value);
+                    return parsed != null ? parsed : value;
+                }
+                return value;
+            case INTEGER:
+                if (value instanceof String) {
+                    Long parsed = parseLongOrNull((String) value);
+                    return parsed != null ? parsed : value;
+                }
+                return value;
+            case STRING_ARRAY:
+            case ARRAY:
+            default:
+                return value;
+        }
+    }
+
+    // Whether a value matches the type Braze expects. 0 / false are valid for their types; a numeric
+    // written as a string (e.g. "29.99") does not match a numeric type.
+    private static boolean matchesType(Object value, BrazeFieldType type) {
+        switch (type) {
+            case STRING:
+                return value instanceof String;
+            case INTEGER:
+                return value instanceof Number && isIntegral((Number) value);
+            case FLOAT:
+                return value instanceof Number;
+            case STRING_ARRAY:
+                return isStringList(value);
+            case ARRAY:
+                return value instanceof List;
+            default:
+                return true;
+        }
+    }
+
+    private static boolean isIntegral(Number value) {
+        if (value instanceof Integer || value instanceof Long || value instanceof Short
+                || value instanceof Byte || value instanceof BigInteger) {
+            return true;
+        }
+        double d = value.doubleValue();
+        return !Double.isNaN(d) && !Double.isInfinite(d) && d == Math.floor(d);
+    }
+
+    private static boolean isStringList(Object value) {
+        if (!(value instanceof List)) {
+            return false;
+        }
+        for (Object item : (List<?>) value) {
+            if (!(item instanceof String)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Double parseDoubleOrNull(String value) {
+        try {
+            return Double.valueOf(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static Long parseLongOrNull(String value) {
+        try {
+            return Long.valueOf(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 }

--- a/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
+++ b/braze/src/main/java/com/rudderstack/android/integration/braze/Utils.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 // Stateless mapping logic for Braze recommended ecommerce events (gated by
-// useRecommendedEcommerceEvents). Every method here is a pure props -> Map transform; the actual
+// useEcommerceRecommendedEvents). Every method here is a pure props -> Map transform; the actual
 // braze.logCustomEvent call stays in BrazeIntegrationFactory.
 class Utils {
 
@@ -114,9 +114,10 @@ class Utils {
     private static final Set<String> PRODUCT_VIEWED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
             EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_PRICE, EC_CURRENCY, EC_IMAGE_URL, EC_URL,
             EC_TYPE));
-    private static final Set<String> CART_UPDATED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
-            EC_CART_ID, EC_CURRENCY, EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE,
-            EC_IMAGE_URL, EC_URL, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING));
+    // Cart-level keys always consumed by cart_updated. Product-field keys (PRODUCT_CONSUMED_KEYS) or
+    // EC_PRODUCTS are added per-event by cartUpdatedConsumedKeys depending on the payload shape.
+    private static final Set<String> CART_UPDATED_BASE_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
+            EC_CART_ID, EC_CURRENCY, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING));
     private static final Set<String> CHECKOUT_STARTED_CONSUMED_KEYS = new HashSet<>(Arrays.asList(
             EC_CHECKOUT_ID, EC_ORDER_ID, EC_CART_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE,
             EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING));
@@ -302,19 +303,32 @@ class Utils {
         return out;
     }
 
-    // ecommerce.cart_updated — Product Added/Removed; single top-level product wrapped into a
-    // 1-element products array. action is the only difference between add and remove.
+    // ecommerce.cart_updated — Product Added/Removed. An explicit products[] is mapped item-by-item;
+    // otherwise the top-level product fields are folded into a single-element products array. action is
+    // the only difference between add and remove.
     private static Map<String, Object> buildCartUpdated(Map<String, Object> props, String action) {
         String brazeEvent = EcommerceEvent.PRODUCT_ADDED.brazeEvent; // ecommerce.cart_updated
         Map<String, Object> out = new HashMap<>();
 
         Object cartId = firstNonNull(props, EC_CART_ID);
         Object currency = firstNonNull(props, EC_CURRENCY);
-        Map<String, Object> product = buildProductFields(props);
+
+        List<Map<String, Object>> products;
+        if (explicitProductsArray(props) != null) {
+            products = buildProducts(props);
+        } else {
+            Map<String, Object> product = buildProductFields(props);
+            if (product.isEmpty()) {
+                products = null;
+            } else {
+                products = new ArrayList<>();
+                products.add(product);
+            }
+        }
 
         warnIfMissing(brazeEvent, BRAZE_CART_ID, cartId);
         warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
-        if (product.isEmpty()) {
+        if (products == null) {
             warnIfMissing(brazeEvent, BRAZE_PRODUCTS, null);
         }
 
@@ -325,14 +339,12 @@ class Utils {
         putIfPresent(out, BRAZE_TAX, firstNonNull(props, EC_TAX));
         putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
         out.put(BRAZE_ACTION, action);
-        if (!product.isEmpty()) {
-            List<Map<String, Object>> products = new ArrayList<>();
-            products.add(product);
+        if (products != null) {
             out.put(BRAZE_PRODUCTS, products);
         }
         out.put(SOURCE_KEY, SOURCE);
 
-        putMetadata(out, props, CART_UPDATED_CONSUMED_KEYS);
+        putMetadata(out, props, cartUpdatedConsumedKeys(props));
         return out;
     }
 
@@ -365,7 +377,7 @@ class Utils {
         putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, EC_SHIPPING));
         out.put(SOURCE_KEY, SOURCE);
 
-        putMetadata(out, props, CHECKOUT_STARTED_CONSUMED_KEYS);
+        putMetadata(out, props, consumedKeysWithProductsArray(CHECKOUT_STARTED_CONSUMED_KEYS, props));
         return out;
     }
 
@@ -401,7 +413,7 @@ class Utils {
         putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
-        putMetadata(out, props, ORDER_PLACED_CONSUMED_KEYS);
+        putMetadata(out, props, consumedKeysWithProductsArray(ORDER_PLACED_CONSUMED_KEYS, props));
         return out;
     }
 
@@ -433,7 +445,7 @@ class Utils {
         putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
-        putMetadata(out, props, ORDER_REFUNDED_CONSUMED_KEYS);
+        putMetadata(out, props, consumedKeysWithProductsArray(ORDER_REFUNDED_CONSUMED_KEYS, props));
         return out;
     }
 
@@ -471,30 +483,65 @@ class Utils {
         putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, EC_DISCOUNTS));
         out.put(SOURCE_KEY, SOURCE);
 
-        putMetadata(out, props, ORDER_CANCELLED_CONSUMED_KEYS);
+        putMetadata(out, props, consumedKeysWithProductsArray(ORDER_CANCELLED_CONSUMED_KEYS, props));
         return out;
     }
 
+    // Returns props[products] only when it is a list whose every element is a Map. A non-list or
+    // mixed/malformed list returns null so the original value can flow through to metadata (never dropped).
     @SuppressWarnings("unchecked")
-    private static List<Map<String, Object>> buildProducts(Map<String, Object> props) {
+    private static List<Map<String, Object>> explicitProductsArray(Map<String, Object> props) {
         Object raw = props.get(EC_PRODUCTS);
         if (!(raw instanceof List)) {
             return null;
         }
-        List<?> rsProducts = (List<?>) raw;
+        for (Object item : (List<?>) raw) {
+            if (!(item instanceof Map)) {
+                return null;
+            }
+        }
+        return (List<Map<String, Object>>) raw;
+    }
+
+    private static List<Map<String, Object>> buildProducts(Map<String, Object> props) {
+        List<Map<String, Object>> rsProducts = explicitProductsArray(props);
+        if (rsProducts == null) {
+            return null;
+        }
         List<Map<String, Object>> products = new ArrayList<>();
-        for (Object item : rsProducts) {
-            if (item instanceof Map) {
-                Map<String, Object> product = buildProduct((Map<String, Object>) item);
-                // Skip empty product maps so an all-empty products array is treated as "no products"
-                // (omitted + missing-field warning) rather than sending products: [ {} ]. Mirrors the
-                // Kotlin integration's trailing filter { it.isNotEmpty() }.
-                if (!product.isEmpty()) {
-                    products.add(product);
-                }
+        for (Map<String, Object> item : rsProducts) {
+            Map<String, Object> product = buildProduct(item);
+            // Skip empty product maps so an all-empty products array is treated as "no products"
+            // (omitted + missing-field warning) rather than sending products: [ {} ]. Mirrors the
+            // Kotlin integration's trailing filter { it.isNotEmpty() }.
+            if (!product.isEmpty()) {
+                products.add(product);
             }
         }
         return products.isEmpty() ? null : products;
+    }
+
+    // Cart-level keys are always consumed. With an explicit products[] its items are mapped and
+    // products is consumed; otherwise the top-level product fields are folded into products[0] and consumed.
+    private static Set<String> cartUpdatedConsumedKeys(Map<String, Object> props) {
+        Set<String> keys = new HashSet<>(CART_UPDATED_BASE_CONSUMED_KEYS);
+        if (explicitProductsArray(props) != null) {
+            keys.add(EC_PRODUCTS);
+        } else {
+            keys.addAll(PRODUCT_CONSUMED_KEYS);
+        }
+        return keys;
+    }
+
+    // products is consumed (kept out of metadata) only when it is an explicit array of objects we build
+    // from. A non-array/malformed value is left unconsumed so it flows through to metadata, not dropped.
+    private static Set<String> consumedKeysWithProductsArray(Set<String> base, Map<String, Object> props) {
+        if (explicitProductsArray(props) != null) {
+            return base;
+        }
+        Set<String> adjusted = new HashSet<>(base);
+        adjusted.remove(EC_PRODUCTS);
+        return adjusted;
     }
 
     private static Map<String, Object> buildProduct(Map<String, Object> rsProduct) {

--- a/braze/src/test/java/com/rudderstack/android/integration/braze/UtilsTest.java
+++ b/braze/src/test/java/com/rudderstack/android/integration/braze/UtilsTest.java
@@ -1,0 +1,236 @@
+package com.rudderstack.android.integration.braze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.rudderstack.android.integration.braze.Utils.EcommerceEvent;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+// Unit tests for the recommended-ecommerce mapping in Utils. Pure-Map assertions need no Android
+// runtime (RudderLogger is a no-op at the default log level); the JSON-preservation test uses the
+// real org.json pulled in as a test dependency. The JSON test specifically guards the fix for the
+// bug where BrazeProperties(Map) dropped List values (products / discounts / type).
+public class UtilsTest {
+
+    // ----- helpers -----
+
+    private static Map<String, Object> map(Object... pairs) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            m.put((String) pairs[i], pairs[i + 1]);
+        }
+        return m;
+    }
+
+    private static List<Object> list(Object... items) {
+        return new ArrayList<>(Arrays.asList(items));
+    }
+
+    private static Map<String, Object> buildOrderCompleted(Map<String, Object> props) {
+        return Utils.buildEcommerceProperties(EcommerceEvent.ORDER_COMPLETED, props);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> firstProduct(Map<String, Object> out) {
+        List<Map<String, Object>> products = (List<Map<String, Object>>) out.get("products");
+        return products.get(0);
+    }
+
+    // ----- resolveEcommerceEvent -----
+
+    @Test
+    public void resolveEcommerceEvent_mapsKnownEventsCaseInsensitively() {
+        assertEquals(EcommerceEvent.ORDER_COMPLETED, Utils.resolveEcommerceEvent("Order Completed"));
+        assertEquals(EcommerceEvent.ORDER_COMPLETED, Utils.resolveEcommerceEvent("order completed"));
+        assertEquals(EcommerceEvent.ORDER_COMPLETED, Utils.resolveEcommerceEvent("  Order Completed  "));
+        assertEquals(EcommerceEvent.PRODUCT_VIEWED, Utils.resolveEcommerceEvent("Product Viewed"));
+        assertEquals(EcommerceEvent.PRODUCT_ADDED, Utils.resolveEcommerceEvent("Product Added"));
+        assertEquals(EcommerceEvent.PRODUCT_REMOVED, Utils.resolveEcommerceEvent("Product Removed"));
+
+        assertEquals("ecommerce.order_placed", EcommerceEvent.ORDER_COMPLETED.getBrazeEvent());
+        assertEquals("ecommerce.cart_updated", EcommerceEvent.PRODUCT_ADDED.getBrazeEvent());
+    }
+
+    @Test
+    public void resolveEcommerceEvent_returnsNullForUnmappedOrNull() {
+        // Product Clicked and Cart Viewed intentionally stay generic custom events.
+        assertNull(Utils.resolveEcommerceEvent("Product Clicked"));
+        assertNull(Utils.resolveEcommerceEvent("Cart Viewed"));
+        assertNull(Utils.resolveEcommerceEvent("Some Random Event"));
+        assertNull(Utils.resolveEcommerceEvent(null));
+    }
+
+    // ----- Order Completed -> ecommerce.order_placed mapping -----
+
+    @Test
+    public void orderCompleted_mapsCoreFieldsAndProducts() {
+        Map<String, Object> out = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "total", 200,
+                "currency", "USD",
+                "products", list(map(
+                        "product_id", "P1",
+                        "name", "Mug",
+                        "price", 12.5,
+                        "quantity", 3))));
+
+        assertEquals("O-100", out.get("order_id"));
+        assertEquals("USD", out.get("currency"));
+        assertEquals(200, ((Number) out.get("total_value")).intValue());
+        assertEquals("android", out.get("source"));
+
+        Map<String, Object> product = firstProduct(out);
+        assertEquals("P1", product.get("product_id"));
+        assertEquals("Mug", product.get("product_name"));
+        // variant_id falls back to sku -> product_id when absent.
+        assertEquals("P1", product.get("variant_id"));
+        assertEquals(12.5, ((Number) product.get("price")).doubleValue(), 0.0);
+        assertEquals(3, ((Number) product.get("quantity")).intValue());
+    }
+
+    @Test
+    public void orderCompleted_totalValueFallsBackTotalThenRevenueThenValue() {
+        assertEquals(200, ((Number) buildOrderCompleted(map("total", 200, "revenue", 1, "value", 2))
+                .get("total_value")).intValue());
+        assertEquals(50, ((Number) buildOrderCompleted(map("revenue", 50, "value", 2))
+                .get("total_value")).intValue());
+        assertEquals(30, ((Number) buildOrderCompleted(map("value", 30))
+                .get("total_value")).intValue());
+    }
+
+    // ----- metadata pass-through (D6) -----
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void metadata_unmappedKeysRoutedToMetadataNotTopLevel() {
+        Map<String, Object> out = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "affiliation", "web-store",            // unmapped top-level
+                "products", list(map(
+                        "product_id", "P1",
+                        "color", "blue"))));            // unmapped product key
+
+        // Unmapped top-level key must not leak to the top level; it lives under metadata.
+        assertFalse(out.containsKey("affiliation"));
+        Map<String, Object> metadata = (Map<String, Object>) out.get("metadata");
+        assertEquals("web-store", metadata.get("affiliation"));
+
+        Map<String, Object> product = firstProduct(out);
+        assertFalse(product.containsKey("color"));
+        Map<String, Object> productMetadata = (Map<String, Object>) product.get("metadata");
+        assertEquals("blue", productMetadata.get("color"));
+    }
+
+    // ----- type coercion -----
+
+    @Test
+    public void coercion_numericStringsBecomeNumbersAndNumbersBecomeStrings() {
+        Map<String, Object> out = buildOrderCompleted(map(
+                "total", "199.99",                      // FLOAT field, numeric string -> double
+                "products", list(map(
+                        "product_id", 1001,             // STRING field, number -> string
+                        "price", "12.5",                // FLOAT field, numeric string -> double
+                        "quantity", "3"))));            // INTEGER field, numeric string -> long
+
+        assertEquals(199.99, ((Number) out.get("total_value")).doubleValue(), 0.0);
+
+        Map<String, Object> product = firstProduct(out);
+        assertTrue(product.get("product_id") instanceof String);
+        assertEquals("1001", product.get("product_id"));
+        assertEquals(12.5, ((Number) product.get("price")).doubleValue(), 0.0);
+        assertEquals(3, ((Number) product.get("quantity")).intValue());
+    }
+
+    @Test
+    public void coercion_unparsableValueLeftAsIs() {
+        // "free" cannot be coerced to a FLOAT price; it is sent verbatim (warned, never dropped).
+        Map<String, Object> product = firstProduct(buildOrderCompleted(map(
+                "order_id", "O-100",
+                "products", list(map("product_id", "P1", "price", "free")))));
+        assertEquals("free", product.get("price"));
+    }
+
+    // ----- empty products (fix #2) -----
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void emptyProducts_areOmittedNotSentAsEmptyObject() {
+        // A products array of only-empty maps must be treated as "no products" (key omitted),
+        // never sent as products: [ {} ].
+        Map<String, Object> out = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "products", list(new HashMap<String, Object>())));
+        assertFalse(out.containsKey("products"));
+
+        // A mix keeps only the non-empty product.
+        Map<String, Object> mixed = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "products", list(new HashMap<String, Object>(), map("product_id", "P1"))));
+        List<Map<String, Object>> products = (List<Map<String, Object>>) mixed.get("products");
+        assertEquals(1, products.size());
+        assertEquals("P1", products.get(0).get("product_id"));
+    }
+
+    // ----- toBrazeJson preserves arrays (fix #1 guard) -----
+
+    @Test
+    public void toBrazeJson_preservesProductsAndDiscountsAsJsonArrays() throws Exception {
+        Map<String, Object> out = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "total", 200,
+                "currency", "USD",
+                "affiliation", "web-store",            // unmapped top-level -> metadata
+                "discounts", list(map("code", "WELCOME", "amount", 15)),
+                "products", list(
+                        map("product_id", "P1", "name", "Mug", "color", "blue"),
+                        map("product_id", "P2", "name", "Saucer"))));
+
+        JSONObject json = Utils.toBrazeJson(out);
+
+        // Scalars survive unchanged.
+        assertEquals("O-100", json.get("order_id"));
+        assertEquals("USD", json.get("currency"));
+
+        // The arrays that BrazeProperties(Map) used to drop are now real JSONArrays.
+        assertTrue(json.get("products") instanceof JSONArray);
+        JSONArray products = json.getJSONArray("products");
+        assertEquals(2, products.length());
+        assertTrue(products.get(0) instanceof JSONObject);
+        assertEquals("P1", products.getJSONObject(0).get("product_id"));
+
+        assertTrue(json.get("discounts") instanceof JSONArray);
+        assertEquals(1, json.getJSONArray("discounts").length());
+
+        // Nested objects (top-level + product metadata) become JSONObjects, not raw Maps.
+        assertTrue(json.get("metadata") instanceof JSONObject);
+        assertTrue(products.getJSONObject(0).get("metadata") instanceof JSONObject);
+        assertEquals("blue", products.getJSONObject(0).getJSONObject("metadata").get("color"));
+    }
+
+    @Test
+    public void toBrazeJson_preservesStringArrayTypeField() throws Exception {
+        // product_viewed's "type" is a STRING_ARRAY; it must survive as a JSONArray.
+        Map<String, Object> out = Utils.buildEcommerceProperties(EcommerceEvent.PRODUCT_VIEWED, map(
+                "product_id", "PV1",
+                "type", list("shoe", "running")));
+
+        JSONObject json = Utils.toBrazeJson(out);
+        assertTrue(json.get("type") instanceof JSONArray);
+        JSONArray type = json.getJSONArray("type");
+        assertEquals(2, type.length());
+        assertEquals("shoe", type.get(0));
+        assertEquals("running", type.get(1));
+    }
+}

--- a/braze/src/test/java/com/rudderstack/android/integration/braze/UtilsTest.java
+++ b/braze/src/test/java/com/rudderstack/android/integration/braze/UtilsTest.java
@@ -233,4 +233,69 @@ public class UtilsTest {
         assertEquals("shoe", type.get(0));
         assertEquals("running", type.get(1));
     }
+
+    // ----- malformed products -> metadata (never dropped) -----
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void malformedProductsValue_flowsToMetadataNotDropped() {
+        // A non-list products value must not be silently dropped; it is preserved under metadata.
+        Map<String, Object> out = buildOrderCompleted(map(
+                "order_id", "O-100",
+                "products", "not-a-list"));
+        assertFalse(out.containsKey("products"));
+        Map<String, Object> metadata = (Map<String, Object>) out.get("metadata");
+        assertEquals("not-a-list", metadata.get("products"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void mixedProductsArray_flowsToMetadataNotPartiallyMapped() {
+        // A list containing a non-Map element is treated as malformed (all-or-nothing) and preserved
+        // under metadata rather than partially mapped.
+        List<Object> mixed = list(map("product_id", "P1"), "junk");
+        Map<String, Object> out = buildOrderCompleted(map("order_id", "O-100", "products", mixed));
+        assertFalse(out.containsKey("products"));
+        Map<String, Object> metadata = (Map<String, Object>) out.get("metadata");
+        assertEquals(mixed, metadata.get("products"));
+    }
+
+    // ----- cart_updated products[] -----
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void cartUpdated_mapsExplicitProductsArrayItemByItem() {
+        // An explicit products[] on Product Added is mapped item-by-item (not folded from top-level).
+        Map<String, Object> out = Utils.buildEcommerceProperties(EcommerceEvent.PRODUCT_ADDED, map(
+                "cart_id", "C-1",
+                "products", list(
+                        map("product_id", "P1", "name", "Mug"),
+                        map("product_id", "P2", "name", "Saucer"))));
+
+        assertEquals("add", out.get("action"));
+        List<Map<String, Object>> products = (List<Map<String, Object>>) out.get("products");
+        assertEquals(2, products.size());
+        assertEquals("P1", products.get(0).get("product_id"));
+        assertEquals("Mug", products.get(0).get("product_name"));
+        assertEquals("P2", products.get(1).get("product_id"));
+        // products[] is consumed, so it is not duplicated into metadata.
+        assertFalse(out.containsKey("metadata"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void cartUpdated_fallsBackToTopLevelProductFields() {
+        // Without products[], top-level product fields fold into a single-element products array.
+        Map<String, Object> out = Utils.buildEcommerceProperties(EcommerceEvent.PRODUCT_REMOVED, map(
+                "cart_id", "C-1",
+                "product_id", "P1",
+                "name", "Mug",
+                "price", 9.99));
+
+        assertEquals("remove", out.get("action"));
+        List<Map<String, Object>> products = (List<Map<String, Object>>) out.get("products");
+        assertEquals(1, products.size());
+        assertEquals("P1", products.get(0).get("product_id"));
+        assertEquals("Mug", products.get(0).get("product_name"));
+    }
 }


### PR DESCRIPTION
**Fixes** # (N/A)

## Description
Adds support for Braze's recommended ecommerce events (`ecommerce.*`) in the device-mode integration, behind a new opt-in destination flag `useRecommendedEcommerceEvents` (default **off**). When the flag is off, behaviour is unchanged. When on, RudderStack ecommerce `track` events are mapped to the corresponding Braze recommended events via `logCustomEvent`, taking a hard cutover ahead of the legacy `Order Completed → logPurchase` path. All stateless mapping logic is extracted into a new `Utils` class, keeping `BrazeIntegrationFactory` focused on lifecycle and the SDK call.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Implementation Details
- **New opt-in flag** `useRecommendedEcommerceEvents` parsed from the destination config in the constructor (default `false`). Gating is applied only when `connectionMode == device`.
- **Event mapping** (case-insensitive) from RudderStack ecommerce events to Braze recommended events:
  - `Product Viewed → ecommerce.product_viewed`
  - `Product Added → ecommerce.cart_updated` (action `add`)
  - `Product Removed → ecommerce.cart_updated` (action `remove`)
  - `Checkout Started → ecommerce.checkout_started`
  - `Order Completed → ecommerce.order_placed`
  - `Order Refunded → ecommerce.order_refunded`
  - `Order Cancelled → ecommerce.order_cancelled`
  - Events with no recommended-event counterpart (e.g. Product Clicked, Cart Viewed, Install Attributed) fall through and keep their existing behaviour.
- **Hard cutover** for `Order Completed`: when the flag is on, it emits `ecommerce.order_placed` (one event per order) instead of the legacy per-product `logPurchase`.
- **Property mapping** uses RudderStack's own SDK constants (`ECommerceEvents` / `ECommerceParamNames`) for event and param names wherever the SDK exposes them; the few source keys without a constant (e.g. `sku`, `name`, `variant`, `image_url`, `url`, `value`, `tax`, `shipping`, `cancel_reason`) are kept as clearly-commented local literals.
- **Fallback chains** for resilient mapping: `total → revenue → value`, `product_id → sku`, `variant → sku → product_id`, `checkout_id → order_id`.
- **Metadata pass-through**: any source key not consumed by a top-level/product mapping is routed into `metadata` / `products[].metadata`, never left as an unexpected top-level property (which Braze rejects).
- **Send-anyway validation**: missing Braze-required fields are logged via `logger.warn` but the event is still sent (no drops); `source` is hardcoded per platform (`android`).
- **Refactor**: extracted the enum, all mapping constants, the lookup table, per-event builders, and helpers into a new stateless `Utils` class; the factory now delegates via `Utils.resolveEcommerceEvent(...)` and `Utils.buildEcommerceProperties(...)` and performs the single `braze.logCustomEvent` call.
- **No SDK bump**: nested `products[]`/`metadata` custom-event properties are supported on the current Braze SDK pin.

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## How to test?
1. Configure a Braze destination in device mode with `useRecommendedEcommerceEvents` enabled.
2. Send the supported ecommerce `track` events (e.g. `Product Viewed`, `Product Added`, `Order Completed`) with representative properties.
3. Verify in Braze that the corresponding `ecommerce.*` custom events are received with the expected mapped properties, `products[]`/`metadata` nesting, and `source = android`.
4. Toggle the flag off and confirm legacy behaviour is unchanged (`Order Completed → logPurchase`).

## Breaking Changes
None. The feature is gated behind a new flag that defaults to off; existing behaviour is preserved when the flag is disabled.
