### PR TITLE
fix(release): commit package.json and package-lock.json in draft release

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -93,6 +93,8 @@ jobs:
           files: |
             CHANGELOG.md
             gradle.properties
+            package.json
+            package-lock.json
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5


### PR DESCRIPTION
**Fixes** # (*release version-bump drift*)

Adds `package.json` and `package-lock.json` to the signed-commit file list in the `Draft new release` workflow so their `standard-version` bumps are actually persisted.

## Context

The release flow uses `standard-version` (driven by `.versionrc`) to bump the version across `package.json`, `package-lock.json`, and `gradle.properties`. After the SEC-58 migration to signed commits, the `Create verified commit with changelog and version bump` step in `draft_new_release.yml` only committed `CHANGELOG.md` and `gradle.properties`. As a result:

- `standard-version` bumped `package.json`/`package-lock.json` during the run, but those changes were never committed and got discarded.
- `standard-version` reads its **baseline version from `package.json`**, so a stale `package.json` (left at the previous release version) would mis-compute the next release version.

This change re-adds the two files to the committed set so all four version-bearing files stay in sync each release.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Implementation Details
- `.github/workflows/draft_new_release.yml`: add `package.json` and `package-lock.json` to the `files:` input of the `ryancyq/github-signed-commit` step, alongside the existing `CHANGELOG.md` and `gradle.properties`.

## How to test?
- Trigger the `Draft new release` workflow from a `feat/*` or `fix/*` branch.
- Verify the generated `chore(release): vX.Y.Z` commit on the `release/X.Y.Z` branch updates **all four** files — `CHANGELOG.md`, `gradle.properties`, `package.json`, and `package-lock.json` — to the new version.
- Confirm `package.json`/`package-lock.json` version matches `gradle.properties` `VERSION_NAME` after the run.

## Breaking Changes
None. CI/release tooling only; no runtime or public API changes.

## Additional Context
This is a prerequisite for cutting the next release cleanly (v2.3.0). Without it, the `package.json` baseline drifts from the released version and future version calculations become incorrect.
