### PR TITLE
fix(release): fetch full master history when calculating release version

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
-          git fetch origin master --depth=1
+          git fetch origin master
           git merge origin/master --allow-unrelated-histories
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
 


### PR DESCRIPTION
**Fixes** # (*incorrect release version & truncated changelog in the draft-release workflow*)

Removes `--depth=1` from the `git fetch origin master` call in the `Draft new release` workflow so `standard-version` sees the full commit history when calculating the next release version.

## Context

The `Calculate release version` step fetched master with `--depth=1`, which makes the local repo **shallow**. `standard-version` (via conventional-changelog) then walks only a single commit back from `HEAD` and stops at the shallow boundary, so:

- The release type (major/minor/patch) is derived from **only the tip commit** instead of all commits since the last tag.
- The generated changelog is truncated to that single commit (and loses the `compare/<prev>...<new>` link because the previous tag is unreachable).

This surfaced when a release had more than one commit since the last tag: with a `feat` (`#63`) followed by a `fix` (`#65`), the draft computed `2.2.1` (patch, from the tip `fix`) instead of the correct `2.3.0` (minor, from the `feat`). `actions/checkout` already runs with `fetch-depth: 0`, so full history is available; the extra shallow fetch was both redundant and harmful.

## Verification (local dry runs)

Reproduced both paths with `standard-version --dry-run` in throwaway clones:

| History | `git rev-list --count HEAD` | Computed version | Changelog |
| -- | -- | -- | -- |
| Shallow (`--depth=1`) | `1` | `2.2.0 → 2.2.1` ❌ | tip commit only, no compare link |
| Full (this fix) | full | `2.2.0 → 2.3.0` ✅ | feat `#63` + fixes, with compare link |

Also confirmed no `BREAKING CHANGE`/`!` markers exist since `v2.2.0`, so the full-history scan yields a minor bump (`2.3.0`), not a major one.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Implementation Details
- `.github/workflows/draft_new_release.yml`: change `git fetch origin master --depth=1` to `git fetch origin master` in the `Calculate release version` step so the version/changelog are computed from the complete commit range since the last tag.

## How to test?
- Trigger the `Draft new release` workflow from a `feat/*` or `fix/*` branch that has more than one commit since the last tag, where the tip commit is a lower-priority type than an earlier one (e.g. a `fix` on top of a `feat`).
- Verify the computed version reflects the **highest-priority** change across all commits since the last tag (e.g. a `feat` anywhere in the range yields a minor bump).
- Verify the generated `CHANGELOG.md` section lists all relevant commits since the last tag and includes the `compare/<prev>...<new>` link.

## Breaking Changes
None. CI/release tooling only; no runtime or public API changes. `--allow-unrelated-histories` on the following merge becomes a harmless no-op now that the histories share a common ancestor.

## Additional Context
Prerequisite for cutting v2.3.0 correctly. Without it, the draft mis-computes the version and produces an incomplete changelog whenever multiple commits exist since the last release.
